### PR TITLE
Makefile for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,12 @@ debug: ## debug
 	sleep 10
 	$(MAKE) mysql
 	octave-cli bug.m
+
+
+macos_mysql: ## build against -lmysqlclient
+		mkoctfile --mex  -DDEBUG -L/usr/lib -L/usr/local/lib -L/usr/local/Cellar/mysql/8.0.30_1/lib -lmysqlclient -I/usr/local/Cellar/mysql/8.0.30_1/include/mysql mariadb.c
+		mv mariadb.mex mariadb_.mex
+
+macos_mariadb: ## build against -lmariadbclient
+		mkoctfile --mex  -DDEBUG -L/usr/lib -L/usr/local/lib -L/usr/local/Cellar/mariadb/10.8.3_1/lib -lmariadb -I/usr/local/Cellar/mysql/8.0.30_1/include/mysql mariadb.c
+		mv mariadb.mex mariadb_.mex

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 * test compiling
   * MariaDB 5.5 @ Centos 7 
-  * MariaDB 10.2 @ Alpine Linux 
+  * MariaDB 10.2 @ Alpine Linux
+  * MariaDB 10.3.29 @ macOS Big Sur 11.7.1  
 * run tests against
   * MariaDB 10.1
   * MariaDB 10.2
@@ -23,6 +24,8 @@
 $ make
 mkoctfile --mex  -L/usr/lib  -lmysqlclient -lpthread -lz -lm -ldl -lssl -lcrypto -I/usr/include/mysql mariadb.c
 ```
+
+On macOS use `make macos_mariadb` or `make macos_mysql` depending on which binaries are installed (MariaDB or MySQL). Use Homebrew to install the binary libraries with `brew install mariadb` or `brew install mysql`.
 
 
 # example


### PR DESCRIPTION
Added macOS build options on Makefile. Tested Ok on macOS 11.7.1 and macOS 13.
Binaries for compilation (libs and includes) installed with Homebrew. Works well with MariaDB and MySQL libraries (are actually the same binaries).
Tested on MariaDB 10.3.29 running on a Synology NAS. 